### PR TITLE
Add a cron job endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,24 @@ Eg.
 ```
 
 ## API
+
 ### POST /harvest
 Trigger a new harvest round. Each harvest round consist of:
 1. Creating a new harvest collection for new downloaded file addresses
 2. Inspecting navigational properties in new downloaded files and triggering additional downloads attached to the same harvest collection. These additional downloads will be harvested in a following round (after the download has successfully finished)
 3. Updating the state of harvest collections for which all files have been harvested
 
+### Cron job trigger
+
+In case you need to harvest tasks that you created manually, for example via migrations, a cron job trigger exists. This can be useful if there is the need to harvest a big number of URLs that cannot be accessed via the `linkToPublication` tag.
+
+To trigger it, you can use the following environment variables:
+```
+ALLOW_CRON_JOB (default 'false'): true if we should run the cron jobs, false otherwise
+CRON_FREQUENCY (default '*/5 * * * *''): cron jobs frequency
+SCHEDULED_TASK_CREATOR (default 'http://lblod.data.gift/services/migrations'): URI of the creator of the scheduled collecting tasks
+```
+
 ## Restrictions
+
 The service expects HTML files containing at least a `body` tag.

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-import { updateSudo as update } from '@lblod/mu-auth-sudo';
+import { updateSudo as update, querySudo as query } from '@lblod/mu-auth-sudo';
 import bodyParser from 'body-parser';
 import flatten from 'lodash.flatten';
 import { app, errorHandler, sparqlEscapeUri } from 'mu';
@@ -14,11 +14,28 @@ import {
 import { Delta } from './lib/delta';
 import { ensureFilesAreReadyForHarvesting, handleDownloadFailure, harvestRemoteDataObject, isRelevantRemoteDataObject } from './lib/harvest';
 import { ProcessingQueue } from './lib/processing-queue';
-import { appendTaskError, isTask, loadTask, updateTaskStatus } from './lib/task';
+import { appendTaskError, loadTask, updateTaskStatus, getScheduledTasks } from './lib/task';
+import { CronJob } from 'cron';
+import { cronFrequency, deleteBatchSize } from './config'
 
 const queue = new ProcessingQueue('Main Queue');
 
 app.use(bodyParser.json({ type: function (req) { return /^application\/json/.test(req.get('content-type')); } }));
+
+// ---------- CRON JOB ----------
+
+/**
+ * Engage harvesting flow by preparing scheduled tasks and their remote files.
+ * The delta flow picks up the rest as soon as the files are downloaded.
+*/
+new CronJob(cronFrequency, function() {
+  console.log(`Collecting scheduled tasks triggered by cron job at ${new Date().toISOString()}`);
+  queue.addJob(async () => processScheduledTasks(), async (error) => {
+    console.error(`Something went wrong.`, error);
+  });
+}, null, true);
+
+// ---------- API ----------
 
 app.post("/on-download-failure", (req, res, next) => {
   queue.addJob(async () => onFailure(req.body), async (error) => {
@@ -26,6 +43,21 @@ app.post("/on-download-failure", (req, res, next) => {
   });
   return res.status(200).send();
 });
+
+/**
+ * Harvests downloaded files that have not been harvested before via deltas.
+ * The harvesting may generate new remote data to be download and harvested.
+ * All related files are collected in a harvest collection.
+*/
+app.post('/delta', async function (req, res, next) {
+  console.log("DELTA ENDPOINT CALLED, NEW JOB ON THE WAY");
+  queue.addJob(async () => processDelta(req.body), async (error) => {
+    console.error(`Something went wrong.`, error);
+  });
+  return res.status(202).end();
+});
+
+// ---------- LOGIC ----------
 
 async function onFailure(data) {
   const remoteDatasMaxFailure = await getRemoteFileUris(data, FILE_DOWNLOAD_FAILURE);
@@ -36,7 +68,6 @@ async function onFailure(data) {
     });
   }
 }
-
 
 async function processDelta(data) {
   //Delta may contain mutiple blobs of information. Hence this block of code does two things
@@ -59,17 +90,19 @@ async function processDelta(data) {
   console.log(`We're done! Let's wait for the next harvesting round...`);
 }
 
-/**
- * Harvests downloaded files that have not been harvested before.
- * The harvesting may generate new remote data to be download and harvested.
- * All related files are collected in a harvest collection.
-*/
-app.post('/delta', async function (req, res, next) {
-  queue.addJob(async () => processDelta(req.body), async (error) => {
-    console.error(`Something went wrong.`, error);
-  });
-  return res.status(202).end();
-});
+async function processScheduledTasks() {
+  // Handle scheduled tasks
+  const scheduledTasks = await getScheduledTasks();
+  console.log(`Received ${scheduledTasks ? scheduledTasks.length : 0} task(s) to collect`);
+  if (scheduledTasks && scheduledTasks.length) {
+    console.log('Starting the collecting...');
+    await startCollectingTasks(scheduledTasks);
+  }
+
+  // It's all that needs to be done here, once the remote files will be downloaded
+  // we'll fall back in the delta flow
+  console.log(`We're done! Let's wait for the delta flow to pick up downloaded remote files!`);
+}
 
 /**
  * Returns the inserted succesfully downloaded remote file URIs
@@ -123,58 +156,105 @@ function isCollectingTask(task) {
 }
 
 async function scheduleRemoteDataObjectsForDownload(task) {
-  const deleteStatusQuery = `
+  const count = await countRemoteDataObjects(task);
+  console.log(`Schedueling ${count} remote data objects for task ${task.task}`);
+
+  let offset = 0;
+  while (offset < count) {
+    const deleteStatusQuery = `
+      ${PREFIXES}
+      DELETE {
+        GRAPH ?g {
+          ?remoteDataObject adms:status ?status.
+        }
+      }
+      WHERE {
+        SELECT ?g ?remoteDataObject ?status
+        WHERE {
+          GRAPH ?g {
+            ?remoteDataObject adms:status ?status.
+          }
+          BIND(${sparqlEscapeUri(task.task)} as ?task)
+          ?task a ${sparqlEscapeUri(TASK_TYPE)};
+            task:inputContainer ?container.
+          ?container task:hasHarvestingCollection ?collection.
+          ?collection a hrvst:HarvestingCollection.
+          ?collection dct:hasPart ?remoteDataObject.
+          ?remoteDataObject a nfo:RemoteDataObject.
+        }
+        LIMIT ${deleteBatchSize}
+      }
+    `;
+
+    await update(deleteStatusQuery);
+    offset += deleteBatchSize;
+    console.log(`Deleted ${offset < count ? offset : count}/${count} remote file statuses`);
+  }
+
+  // Inserting statuses one by one to keep deltas flowing smoothly to the download-url service
+  // It's the same as in prepareNewDownloads (./lib/harvest.js)
+  const insertBatchSize = 1;
+  offset = 0;
+  while (offset < count) {
+    const insertStatusQuery = `
+      ${PREFIXES}
+
+      INSERT {
+        GRAPH ?g {
+          ?remoteDataObject adms:status ${sparqlEscapeUri(STATUS_READY_TO_BE_CACHED)}.
+        }
+      }
+      WHERE {
+        SELECT ?g ?remoteDataObject
+        WHERE {
+          BIND(${sparqlEscapeUri(task.task)} as ?task)
+  
+          ?task a ${sparqlEscapeUri(TASK_TYPE)};
+            task:inputContainer ?container.
+    
+          ?container task:hasHarvestingCollection ?collection.
+          ?collection a hrvst:HarvestingCollection.
+          ?collection dct:hasPart ?remoteDataObject.
+    
+          GRAPH ?g {
+            ?remoteDataObject a nfo:RemoteDataObject;
+              mu:uuid ?remoteDataObjectUuid .
+          }
+        }
+        ORDER BY ?remoteDataObjectUuid
+        LIMIT ${insertBatchSize}
+        OFFSET ${offset}
+      }
+    `;
+
+    await update(insertStatusQuery);
+    offset += insertBatchSize;
+    console.log(`Inserted ${offset < count ? offset : count}/${count} remote file statuses`);
+  }
+}
+
+async function countRemoteDataObjects(task) {
+  const queryResult = await query(`
     ${PREFIXES}
 
-    DELETE {
+    SELECT (COUNT(?remoteDataObject) as ?count)
+    WHERE {
+      BIND(${sparqlEscapeUri(task.task)} as ?task)
       GRAPH ?g {
         ?remoteDataObject adms:status ?status.
       }
+
+      ?task a ${sparqlEscapeUri(TASK_TYPE)};
+        task:inputContainer ?container.
+
+      ?container task:hasHarvestingCollection ?collection.
+      ?collection a hrvst:HarvestingCollection.
+      ?collection dct:hasPart ?remoteDataObject.
+      ?remoteDataObject a nfo:RemoteDataObject.
     }
-    WHERE {
-     BIND(${sparqlEscapeUri(task.task)} as ?task)
-     GRAPH ?g {
-       ?remoteDataObject adms:status ?status.
-     }
+  `);
 
-     ?task a ${sparqlEscapeUri(TASK_TYPE)};
-       task:inputContainer ?container.
-
-     ?container task:hasHarvestingCollection ?collection.
-     ?collection a hrvst:HarvestingCollection.
-     ?collection dct:hasPart ?remoteDataObject.
-     ?remoteDataObject a nfo:RemoteDataObject.
-  }
-  `;
-
-  await update(deleteStatusQuery);
-
-  const updateQuery = `
-    ${PREFIXES}
-
-    INSERT {
-      GRAPH ?g {
-        ?remoteDataObject adms:status ${sparqlEscapeUri(STATUS_READY_TO_BE_CACHED)}.
-      }
-    }
-    WHERE {
-     BIND(${sparqlEscapeUri(task.task)} as ?task)
-
-     ?task a ${sparqlEscapeUri(TASK_TYPE)};
-       task:inputContainer ?container.
-
-     ?container task:hasHarvestingCollection ?collection.
-     ?collection a hrvst:HarvestingCollection.
-     ?collection dct:hasPart ?remoteDataObject.
-
-     GRAPH ?g {
-       ?remoteDataObject a nfo:RemoteDataObject.
-     }
-  }
-  `;
-
-  await update(updateQuery);
+  return parseInt(queryResult.results.bindings[0].count.value);
 }
-
 
 app.use(errorHandler);

--- a/config.js
+++ b/config.js
@@ -1,3 +1,3 @@
-export const CRON_FREQUENCY = process.env.CRON_FREQUENCY || '19 * * * *';
+export const CRON_FREQUENCY = process.env.CRON_FREQUENCY || '*/5 * * * *';
 export const DELETE_BATCH_SIZE = parseInt(process.env.DELETE_BATCH_SIZE) || 1000;
 export const SCHEDULED_TASK_CREATOR = process.env.SCHEDULED_TASK_CREATOR  || 'http://lblod.data.gift/services/migrations';

--- a/config.js
+++ b/config.js
@@ -1,2 +1,3 @@
-export const cronFrequency = process.env.RECONCILIATION_CRON_PATTERN || '0 18 * * *';
-export const deleteBatchSize = parseInt(process.env.DELETE_BATCH_SIZE) || 1000;
+export const CRON_FREQUENCY = process.env.CRON_FREQUENCY || '19 * * * *';
+export const DELETE_BATCH_SIZE = parseInt(process.env.DELETE_BATCH_SIZE) || 1000;
+export const SCHEDULED_TASK_CREATOR = process.env.SCHEDULED_TASK_CREATOR  || 'http://lblod.data.gift/services/migrations';

--- a/config.js
+++ b/config.js
@@ -1,3 +1,3 @@
 export const CRON_FREQUENCY = process.env.CRON_FREQUENCY || '*/5 * * * *';
-export const DELETE_BATCH_SIZE = parseInt(process.env.DELETE_BATCH_SIZE) || 1000;
+export const ALLOW_CRON_JOB = process.env.ALLOW_CRON_JOB || false;
 export const SCHEDULED_TASK_CREATOR = process.env.SCHEDULED_TASK_CREATOR  || 'http://lblod.data.gift/services/migrations';

--- a/config.js
+++ b/config.js
@@ -1,0 +1,2 @@
+export const cronFrequency = process.env.RECONCILIATION_CRON_PATTERN || '0 18 * * *';
+export const deleteBatchSize = parseInt(process.env.DELETE_BATCH_SIZE) || 1000;

--- a/lib/harvest.js
+++ b/lib/harvest.js
@@ -300,10 +300,10 @@ async function getFile(physicalFile) {
 // todo check in the future if that's still the case, other this could be completely removed.
 // Not that we also cleanup the hash, e.g http://foo.com#blabla, this shouldn't affect
 // extraction. We keep the other query parameters that are necessary for extraction.
-function cleanUrl(url){
-   const uri = new URL(url);
-   uri.hash = '';
-   return uri.toString().replace(/;jsessionid=[a-zA-Z;0-9]*/i, "");
+function cleanUrl(url) {
+  const uri = new URL(url);
+  uri.hash = '';
+  return uri.toString().replace(/;jsessionid=[a-zA-Z;0-9]*/i, "");
 }
 
 /**

--- a/lib/harvest.js
+++ b/lib/harvest.js
@@ -295,6 +295,12 @@ async function getFile(physicalFile) {
   return content;
 }
 
+function cleanUrl(url){
+   const uri = new URL(url);
+   uri.hash = '';
+   return uri.toString().replace(/;jsessionid=[a-zA-Z;0-9]*/i, "");
+}
+
 /**
  * Gets the URLs linking to other documents present in the content of a given remoteDataObject
 */
@@ -307,7 +313,8 @@ async function getLinkedUrls(physicalFile, remoteDataObject) {
   const rdfaStream = rdfParser.parse(textStream, { contentType: contentType, baseIRI: baseUrl });
   const rdfa = await streamToArray(rdfaStream);
   const objects = rdfa.filter(r => r.predicate?.value === 'http://lblod.data.gift/vocabularies/besluit/linkToPublication')
-    .map(r => r.object.value);
+    .map(r => r.object.value)
+    .map(cleanUrl);
   const urls = [...new Set(objects)];
 
   return urls;

--- a/lib/harvest.js
+++ b/lib/harvest.js
@@ -295,6 +295,11 @@ async function getFile(physicalFile) {
   return content;
 }
 
+// Workaround to avoid extracting the same url multiple times because a `jsessionid`
+// is set in the url. This is only relevant of urls using a Java backend.
+// todo check in the future if that's still the case, other this could be completely removed.
+// Not that we also cleanup the hash, e.g http://foo.com#blabla, this shouldn't affect
+// extraction. We keep the other query parameters that are necessary for extraction.
 function cleanUrl(url){
    const uri = new URL(url);
    uri.hash = '';

--- a/lib/task.js
+++ b/lib/task.js
@@ -3,23 +3,10 @@ import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
 import { TASK_TYPE,
          PREFIXES,
          ERROR_URI_PREFIX,
-         ERROR_TYPE } from '../constants';
+         ERROR_TYPE, 
+         STATUS_SCHEDULED,
+         TASK_COLLECTING} from '../constants';
 import { parseResult } from './utils';
-
-export async function isTask( subject ){
-  //TODO: move to ask query
-  const queryStr = `
-   ${PREFIXES}
-   SELECT ?subject WHERE {
-    GRAPH ?g {
-      BIND(${ sparqlEscapeUri(subject) } as ?subject)
-      ?subject a ${ sparqlEscapeUri(TASK_TYPE) }.
-    }
-   }
-  `;
-  const result = await query(queryStr);
-  return result.results.bindings.length;
-}
 
 export async function loadTask( subject ){
   const queryTask = `
@@ -129,4 +116,19 @@ export async function appendTaskError(task, errorMsg){
   `;
 
   await update(queryError);
+}
+
+export async function getScheduledTasks() {
+  const queryStr = `
+    ${PREFIXES}
+    SELECT ?task WHERE {
+      GRAPH ?g {
+        ?task a ${sparqlEscapeUri(TASK_TYPE)} ;
+          adms:status ${sparqlEscapeUri(STATUS_SCHEDULED)};
+          task:operation ${sparqlEscapeUri(TASK_COLLECTING)}
+      }
+    }
+  `;
+  const result = await query(queryStr);
+  return result.results.bindings.length ? result.results.bindings.map(res => res.task.value) : null;
 }

--- a/lib/task.js
+++ b/lib/task.js
@@ -1,30 +1,35 @@
 import { sparqlEscapeUri,  sparqlEscapeString, sparqlEscapeDateTime, uuid } from 'mu';
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
-import { TASK_TYPE,
-         PREFIXES,
-         ERROR_URI_PREFIX,
-         ERROR_TYPE, 
-         STATUS_SCHEDULED,
-         TASK_COLLECTING} from '../constants';
+import {
+  TASK_TYPE,
+  PREFIXES,
+  ERROR_URI_PREFIX,
+  ERROR_TYPE,
+  STATUS_SCHEDULED,
+  STATUS_BUSY,
+  TASK_COLLECTING
+} from '../constants';
+import { SCHEDULED_TASK_CREATOR } from '../config'
+
 import { parseResult } from './utils';
 
 export async function loadTask( subject ){
   const queryTask = `
-   ${PREFIXES}
-   SELECT DISTINCT ?graph ?task ?id ?job ?created ?modified ?status ?index ?operation ?error WHERE {
-    GRAPH ?graph {
-      BIND(${ sparqlEscapeUri(subject) } as ?task)
-      ?task a ${ sparqlEscapeUri(TASK_TYPE) }.
-      ?task dct:isPartOf ?job;
-                    mu:uuid ?id;
-                    dct:created ?created;
-                    dct:modified ?modified;
-                    adms:status ?status;
-                    task:index ?index;
-                    task:operation ?operation.
-      OPTIONAL { ?task task:error ?error. }
+    ${PREFIXES}
+    SELECT DISTINCT ?graph ?task ?id ?job ?created ?modified ?status ?index ?operation ?error WHERE {
+      GRAPH ?graph {
+        BIND(${ sparqlEscapeUri(subject) } as ?task)
+        ?task a ${ sparqlEscapeUri(TASK_TYPE) }.
+        ?task dct:isPartOf ?job;
+                      mu:uuid ?id;
+                      dct:created ?created;
+                      dct:modified ?modified;
+                      adms:status ?status;
+                      task:index ?index;
+                      task:operation ?operation.
+        OPTIONAL { ?task task:error ?error. }
+      }
     }
-   }
   `;
 
   const task = parseResult(await query(queryTask))[0];
@@ -32,11 +37,11 @@ export async function loadTask( subject ){
 
   //now fetch the hasMany. Easier to parse these
   const queryParentTasks = `
-   ${PREFIXES}
-   SELECT DISTINCT ?task ?parentTask WHERE {
-     GRAPH ?g {
-       BIND(${ sparqlEscapeUri(subject) } as ?task)
-       ?task cogs:dependsOn ?parentTask.
+    ${PREFIXES}
+    SELECT DISTINCT ?task ?parentTask WHERE {
+      GRAPH ?g {
+        BIND(${ sparqlEscapeUri(subject) } as ?task)
+        ?task cogs:dependsOn ?parentTask.
       }
     }
   `;
@@ -45,11 +50,11 @@ export async function loadTask( subject ){
   task.parentSteps = parentTasks;
 
   const queryResultsContainers = `
-   ${PREFIXES}
-   SELECT DISTINCT ?task ?resultsContainer WHERE {
-     GRAPH ?g {
-       BIND(${ sparqlEscapeUri(subject) } as ?task)
-       ?task task:resultsContainer ?resultsContainer.
+    ${PREFIXES}
+    SELECT DISTINCT ?task ?resultsContainer WHERE {
+      GRAPH ?g {
+        BIND(${ sparqlEscapeUri(subject) } as ?task)
+        ?task task:resultsContainer ?resultsContainer.
       }
     }
   `;
@@ -58,11 +63,11 @@ export async function loadTask( subject ){
   task.resultsContainers = resultsContainers;
 
   const queryInputContainers = `
-   ${PREFIXES}
-   SELECT DISTINCT ?task ?inputContainer WHERE {
-     GRAPH ?g {
-       BIND(${ sparqlEscapeUri(subject) } as ?task)
-       ?task task:inputContainer ?inputContainer.
+    ${PREFIXES}
+    SELECT DISTINCT ?task ?inputContainer WHERE {
+      GRAPH ?g {
+        BIND(${ sparqlEscapeUri(subject) } as ?task)
+        ?task task:inputContainer ?inputContainer.
       }
     }
   `;
@@ -85,8 +90,8 @@ export async function updateTaskStatus(task, status){
     }
     INSERT {
       GRAPH ?g {
-       ?subject adms:status ${sparqlEscapeUri(status)}.
-       ?subject dct:modified ${sparqlEscapeDateTime(new Date())}.
+        ?subject adms:status ${sparqlEscapeUri(status)}.
+        ?subject dct:modified ${sparqlEscapeDateTime(new Date())}.
       }
     }
     WHERE {
@@ -104,15 +109,15 @@ export async function appendTaskError(task, errorMsg){
   const uri = ERROR_URI_PREFIX + id;
 
   const queryError = `
-   ${PREFIXES}
-   INSERT DATA {
-    GRAPH ${sparqlEscapeUri(task.graph)}{
-      ${sparqlEscapeUri(uri)} a ${sparqlEscapeUri(ERROR_TYPE)};
-        mu:uuid ${sparqlEscapeString(id)};
-        oslc:message ${sparqlEscapeString(errorMsg)}.
-      ${sparqlEscapeUri(task.task)} task:error ${sparqlEscapeUri(uri)}.
+    ${PREFIXES}
+    INSERT DATA {
+      GRAPH ${sparqlEscapeUri(task.graph)}{
+        ${sparqlEscapeUri(uri)} a ${sparqlEscapeUri(ERROR_TYPE)};
+          mu:uuid ${sparqlEscapeString(id)};
+          oslc:message ${sparqlEscapeString(errorMsg)}.
+        ${sparqlEscapeUri(task.task)} task:error ${sparqlEscapeUri(uri)}.
+      }
     }
-   }
   `;
 
   await update(queryError);
@@ -125,9 +130,15 @@ export async function getScheduledTasks() {
       GRAPH ?g {
         ?task a ${sparqlEscapeUri(TASK_TYPE)} ;
           adms:status ${sparqlEscapeUri(STATUS_SCHEDULED)};
-          task:operation ${sparqlEscapeUri(TASK_COLLECTING)}
+          task:operation ${sparqlEscapeUri(TASK_COLLECTING)};
+          dct:created ?created;
+          dct:isPartOf ?job.
+
+        ?job adms:status ${sparqlEscapeUri(STATUS_BUSY)};
+          dct:creator ${sparqlEscapeUri(SCHEDULED_TASK_CREATOR)}.
       }
     }
+    ORDER BY ?created
   `;
   const result = await query(queryStr);
   return result.results.bindings.length ? result.results.bindings.map(res => res.task.value) : null;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.6.0-rc.1",
     "body-parser": "^1.19.0",
+    "cron": "^2.1.0",
     "fs-extra": "^9.0.0",
     "jsdom": "^16.2.2",
     "lodash.flatten": "^4.4.0",


### PR DESCRIPTION
Relates to OP-1860
To be tested with https://github.com/lblod/app-lblod-harvester/pull/18

This PR adds a cron job trigger that takes tasks manually inserted to the DB (so no deltas) and starts the harvesting process for them.
I added a flag to disable the cron jobs by default and to be able to allow them when needed.

It also features @nbittich 's work to remove the `jsessionid` attribute that some vendors set on their pages. It'll help with performances.