### PR TITLE
Make sure to select the correct task

### DIFF
--- a/lib/harvest.js
+++ b/lib/harvest.js
@@ -261,10 +261,14 @@ async function updateHarvestStatus(uri, status) {
 async function getTask(collection) {
   const taskResult = await query(`
     PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+    PREFIX tasko: <http://lblod.data.gift/id/jobs/concept/TaskOperation/>
     SELECT DISTINCT ?task
     WHERE {
       GRAPH ?g {
-        ?task task:inputContainer ?container.
+        ?task
+          a task:Task ;
+          task:operation tasko:collecting ;
+          task:inputContainer ?container.
         ?container task:hasHarvestingCollection ${sparqlEscapeUri(collection)}.
       }
     }


### PR DESCRIPTION
A new service in the beginning of the pipeline (singleton-job) carries its `inputContainer` to its `outputContainer`. This means that, combined with the collecting task, there are 2 tasks that fit the query retrieving the task from a harvesting collection. Only one task, the first one (which is often the singleton-job task), was returned. This task was set to success instead of the collecting task. This meant that the collecting task was never set to success and because of the success of the singleton-job task, the collection task would be respawned due to delta-notifier messages.

**EDIT:**

**How to test**

Check out https://github.com/lblod/app-lblod-harvester/pull/34 and https://github.com/lblod/frontend-harvesting-self-service/pull/28 to run a harvester stack. Note that there are beta builds of the necessary services that you can use to test. Rollback to previous builds to test if the changes made a difference.

Start some harvesting Jobs in the frontend. There is a ~90% chance that your new Job would be stuck in an infinite loop where it keeps creating "collecting" tasks, but never sets them to anything else than "busy". This should be fixed by this PR.